### PR TITLE
Add missing var for lib declaration

### DIFF
--- a/src/MagicWand.js
+++ b/src/MagicWand.js
@@ -1,5 +1,5 @@
 ﻿    
-MagicWand = (function () {
+var MagicWand = (function () {
     var lib = {};
 
     /** Create a binary mask on the image by color threshold


### PR DESCRIPTION
Without this change, I get an `Uncaught ReferenceError: MagicWand is not defined` from the magic wand build (v1.1.4) at line 12:  `MagicWand = (function () {` when including it in an Angular project.